### PR TITLE
fix: --syncmode is empty string

### DIFF
--- a/scripts/start-op-geth.sh
+++ b/scripts/start-op-geth.sh
@@ -21,7 +21,7 @@ if [ -n "${IS_CUSTOM_CHAIN+x}" ]; then
 fi
 
 # Determine syncmode based on NODE_TYPE
-if [ -z "${OP_GETH__SYNCMODE+x}" ]; then
+if [ -z "$OP_GETH__SYNCMODE" ]; then
   if [ "$NODE_TYPE" = "full" ]; then
     export OP_GETH__SYNCMODE="snap"
   else


### PR DESCRIPTION
OP_GETH_SYNCMODE in .env file is set but is empty string. Condition is never met.

Or instead of this PR, you can add to .env:

```.env
# Uncomment the following line to force op-geth to use --syncmode=full
# OP_GETH__SYNCMODE=full
```